### PR TITLE
Capacity Pipelines Charts works on Firefox

### DIFF
--- a/mapcomposer/app/applications/he/static/script/widgets/charts/MGChart.js
+++ b/mapcomposer/app/applications/he/static/script/widgets/charts/MGChart.js
@@ -39,6 +39,7 @@ gxp.charts.MGChart = Ext.extend(Ext.Container, {
     updateDelay: 0,
     deferredRender: false,
     autoScroll: false,
+    dateFormat: "%Y-%m-%dZ",
 
     initComponent: function () {
 
@@ -77,9 +78,11 @@ gxp.charts.MGChart = Ext.extend(Ext.Container, {
         if(this.data){
             var min = Number.POSITIVE_INFINITY;
             var max = Number.NEGATIVE_INFINITY;
+            var formatTime = d3.time.format(this.dateFormat);
             for(var i = 0; i< this.data.length; i++){
                 var datum = this.data[i];
-                datum.date = new Date(datum.date);
+                //datum.date = new Date(datum.date);
+                datum.date = formatTime.parse(datum.date);
                 data.push(datum);
                 max = max > datum.value ? max : datum.value;
                 min = min < datum.value ? min : datum.value;

--- a/mapcomposer/app/applications/he/static/script/widgets/grid/ScheduledCapacitiesGrid.js
+++ b/mapcomposer/app/applications/he/static/script/widgets/grid/ScheduledCapacitiesGrid.js
@@ -159,7 +159,8 @@ gxp.he.grid.ScheduledCapacitiesGrid = Ext.extend(gxp.grid.FeatureGrid, {
                                     }
                                 }),
                                 //xtype: 'gxp_C3Chart'
-                                xtype: 'gxp_MGChart'
+                                xtype: 'gxp_MGChart',
+                                dateFormat : '%Y-%m-%dZ'
 
                             }
                         };


### PR DESCRIPTION
Firefox was rejecting the input dates because it has a strinct parsing policy, so I had to explicitly set the format to "%Y-%m-%dZ".
